### PR TITLE
add sync mode to run script

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func unauthorized(w http.ResponseWriter, addr string) {
 	}
 }
 
-func runScript(name string) {
+func runScript(name string) error {
 	path := fmt.Sprintf("./scripts/%s", name)
 	log.Printf("running %s", path)
 	cmd := exec.Command(
@@ -75,8 +75,11 @@ func runScript(name string) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Println(err)
+		return err
 	}
 	log.Println(string(out))
+
+	return nil
 }
 
 // DeployHandler runs some script to upgrade some service
@@ -109,10 +112,30 @@ func DeployHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// sync mode
+	if values.Get("sync") == "true" {
+		if err = runScript(cfg.Command); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte("deploying is failed")); err != nil {
+				log.Printf("Failed to write response: %v", err)
+			}
+		}
+
+		if _, err := w.Write([]byte("deploying is done")); err != nil {
+			log.Printf("Failed to write response: %v", err)
+		}
+		return
+	}
+
+	// async mode
 	if _, err := w.Write([]byte("deploying...")); err != nil {
 		log.Printf("Failed to write response: %v", err)
 	}
-	go runScript(cfg.Command)
+	go func() {
+		if err = runScript(cfg.Command); err != nil {
+			log.Printf("can't run script: %v", err)
+		}
+	}()
 }
 
 func main() {


### PR DESCRIPTION
Solved #2 

- [x] `runScript` now explicitly returns error
- [x] `DeployHandler` could get `sync` query param to run script in sync way

Query param example: 
`https://$DEPLOY_HOST/deploy/bot-prod?secret=$DEPLOY_KEY&sync=true` – run in sync mode, should return `200` if all is good, otherwise `500`

Absence `sync` or invalid date of `sync` key will be ignored, and a script will be run as usual.  
