### PR TITLE
WIP: Add new service: Shopping Cat Bot

### DIFF
--- a/scripts/deploy_scatb.sh
+++ b/scripts/deploy_scatb.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+docker pull ghcr.io/egregors/shoppingcatbot/scbot:latest
+docker stop scatb
+docker rm -f scatb
+docker run -d --name=scatb --env-file=scatb.env ghcr.io/egregors/shoppingcatbot/scbot

--- a/scripts/deploy_scatb.sh
+++ b/scripts/deploy_scatb.sh
@@ -2,4 +2,4 @@
 docker pull ghcr.io/egregors/shoppingcatbot/scbot:latest
 docker stop scatb
 docker rm -f scatb
-docker run -d --name=scatb --env-file=scatb.env ghcr.io/egregors/shoppingcatbot/scbot
+docker run -d -v /tmp/dumps:/dumps --name=scatb --env-file=scatb.env ghcr.io/egregors/shoppingcatbot/scbot


### PR DESCRIPTION
This is some new work for backdoor.

`scatb` – just a tiny, cute telegram bot for shopping list. Sources: https://github.com/egregors/ShoppingCatBot (it's a private repo for a time, I'll make it public soon)

PR basically include just one thing: add a new deployment script.

- [x] `scatb` deployment script (pull, stop, rm, run)
- [x] add telegram token into `.env` file
- [ ] update `config.json`
- [x] add volume to store \ restore dumps

Not a big deal, isn't?